### PR TITLE
Fixes GitHub Runtime Exception when message is null

### DIFF
--- a/src/PlusPull/GitHub.php
+++ b/src/PlusPull/GitHub.php
@@ -116,7 +116,8 @@ class GitHub
         $this->client->api('pull_request')->merge(
             $this->username,
             $this->repository,
-            $number
+            $number,
+            ''
         );
     }
 


### PR DESCRIPTION
New GitHub API requires a commit_message when merging, instead of null.