### PR TITLE
Fix multiple statuses when all are valid

### DIFF
--- a/src/PlusPull/GitHub/PullRequest.php
+++ b/src/PlusPull/GitHub/PullRequest.php
@@ -74,7 +74,7 @@ class PullRequest
             }
         }
 
-        return $this->statuses[0]['state']=='success';
+        return true;
     }
 
     public function isMergeable()


### PR DESCRIPTION
For some reason the first status check for the last return was incorrect